### PR TITLE
Make sure writable-dom is installable from web-fragments

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import glob from "fast-glob";
-import { build, BuildOptions } from "esbuild";
+import { build } from "esbuild";
 
 (async () => {
   const entryPoints = [];
@@ -9,7 +9,7 @@ import { build, BuildOptions } from "esbuild";
   const outdir = path.resolve("dist");
   const files = glob.stream(["**", "!*.d.ts", "!**/__tests__"], {
     cwd: srcdir,
-  }) as AsyncIterable<string>;
+  });
 
   for await (const file of files) {
     if (path.extname(file) === ".ts") {
@@ -21,7 +21,7 @@ import { build, BuildOptions } from "esbuild";
     }
   }
 
-  const opts: BuildOptions = {
+  const opts = {
     outdir,
     entryPoints,
     outbase: srcdir,

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "url": "https://github.com/marko-js/writable-dom"
   },
   "scripts": {
-    "build": "tsc -b && node -r esbuild-register build",
+    "build": "tsc -b && node build",
     "ci:report": "codecov",
     "ci:test": "nyc npm run mocha -- --forbid-pending --forbid-only",
     "format": "npm run lint:eslint -- --fix && npm run lint:prettier -- --write && (fixpack || true)",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "semantic-release": "^18.0.0",
     "typescript": "^5.5.2"
   },
+  "type": "module",
   "files": [
     "dist",
     "!**/__tests__",


### PR DESCRIPTION
In [web-fragments](https://github.com/web-fragments/web-fragments), when installing the wriable-dom dependency from git we were getting (in CI) the issue that it was using esm imports without defining a type module in its package.json ([example CI run](https://github.com/web-fragments/web-fragments/actions/runs/9906532361/job/27368275873#step:5:34))

So that's what I am addressing in this PR

Unfortunately when I added the type module to the package.json `esbuild-register` started to fail (https://github.com/egoist/esbuild-register/issues/26), so I've also removed that from the build script

With the above changes the the CI builds writable-dom correctly ([example CI run](https://github.com/web-fragments/web-fragments/actions/runs/9907115616/job/27370095973))